### PR TITLE
feat: Add URL storage and search functionality

### DIFF
--- a/options.html
+++ b/options.html
@@ -54,6 +54,25 @@
 <div id="changesContainer">
     <select id="changesDropdown"></select>
 </div>
+
+<hr>
+
+<h2>Manage URLs</h2>
+<form id="urlForm">
+    <label for="officeName">Office Name:</label><br>
+    <input type="text" id="officeName" name="officeName" required><br>
+    <label for="publicUrl">Public URL:</label><br>
+    <input type="url" id="publicUrl" name="publicUrl" required><br>
+    <label for="editUrl">Edit URL:</label><br>
+    <input type="url" id="editUrl" name="editUrl" required><br><br>
+    <button type="submit">Save URL</button>
+</form>
+
+<div id="urlListContainer">
+    <h3>Saved URLs</h3>
+    <ul id="urlList"></ul>
+</div>
+
 <script src="options.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a new feature that allows users to store and manage custom URLs within the extension.

Key changes:
- Adds a "Manage URLs" section to the options page, allowing users to add, view, and delete URLs with an office name, public URL, and edit URL.
- Saves the URL data to `chrome.storage.local` for persistence.
- Integrates the saved URLs into the search functionality in the popup, so they appear in search results.
- Fixes an issue where the list of saved URLs was not loading correctly on the options page.
- Improves the search result display order by showing member results before saved URLs.