### PR TITLE
Add import and export functionality for saved URLs

### DIFF
--- a/options.html
+++ b/options.html
@@ -16,6 +16,11 @@
 
     <div class="container">
         <h2>Manage URLs</h2>
+        <div style="margin-bottom: 1em;">
+            <button id="importButton" class="button">Import URLs</button>
+            <button id="exportButton" class="button">Export URLs</button>
+            <input type="file" id="importFile" hidden accept=".json">
+        </div>
         <form id="urlForm" class="form-container">
             <input type="text" id="officeName" name="officeName" placeholder="Office Name" required>
             <input type="url" id="publicUrl" name="publicUrl" placeholder="Public URL" required>

--- a/options.js
+++ b/options.js
@@ -239,5 +239,59 @@ function deleteUrl(id) {
     });
 }
 
+// --- Import/Export ---
+
+const importButton = document.getElementById('importButton');
+const exportButton = document.getElementById('exportButton');
+const importFile = document.getElementById('importFile');
+
+exportButton.addEventListener('click', () => {
+    chrome.storage.local.get({ savedUrls: [] }, (result) => {
+        const savedUrls = result.savedUrls;
+        const dataStr = JSON.stringify(savedUrls, null, 2);
+        const blob = new Blob([dataStr], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'urls.json';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    });
+});
+
+importButton.addEventListener('click', () => {
+    importFile.click();
+});
+
+importFile.addEventListener('change', (event) => {
+    const file = event.target.files[0];
+    if (!file) {
+        return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+        try {
+            const importedUrls = JSON.parse(e.target.result);
+            if (Array.isArray(importedUrls)) {
+                chrome.storage.local.set({ savedUrls: importedUrls }, () => {
+                    loadAndDisplayUrls();
+                    alert('URLs imported successfully!');
+                });
+            } else {
+                alert('Invalid file format.');
+            }
+        } catch (error) {
+            alert('Error reading file. Please ensure it is a valid JSON file.');
+            console.error('Error parsing JSON:', error);
+        }
+    };
+    reader.readAsText(file);
+});
+
+
 // Initial load
 loadAndDisplayUrls();


### PR DESCRIPTION
This commit adds the ability for users to import and export their saved URLs as a JSON file from the settings page.

Key changes:
- Added "Import URLs" and "Export URLs" buttons to `options.html`.
- Implemented the export functionality in `options.js` to save the current list of URLs to a `urls.json` file.
- Implemented the import functionality in `options.js` to read a `urls.json` file and update the saved URLs in the extension.